### PR TITLE
remove try catch on semver, use loose on gt

### DIFF
--- a/normalize/packages.js
+++ b/normalize/packages.js
@@ -23,7 +23,7 @@ function packages(data, fallback) {
     try { return !!semver.valid(version, true); }
     catch (e) { return false; }
   }).sort(function sort(a, b) {
-    return semver.gt(a, b) ? -1 : 1;
+    return semver.gt(a, b, true) ? -1 : 1;
   }).reduce(function reduce(result, release) {
     result[release] = data.versions[release]._npmUser;
     return result;


### PR DESCRIPTION
If we use `loose` on `semver.valid` we need to use `loose` on `semver.gt` too, otherwise `.gt` fails badly.

Also, it does not seems we need to try - catch `semver.valid`, do you have a use case were it fails with an uncaught?

Thanks @3rd-Eden
