### PR TITLE
Fixing the users.starred endpoint

### DIFF
--- a/endpoints/users.js
+++ b/endpoints/users.js
@@ -125,15 +125,27 @@ Users.prototype.list = function list(name, fn) {
  *
  * @param {String} name The user's name
  * @param {Function} fn The callback.
- * @returns {Assign}
+ * @returns {Array}
  * @api public
  */
 Users.prototype.starred = function starred(name, fn) {
-  return this.view('browseStarUser', {
-    key: name
-  }, fn)
-  .map(this.api.map.simple)
-  .filter(Boolean);
+  var starredPackages = '-/_view/starredByUser?key="'+ encodeURIComponent(name) + '"';
+  var objs = [];
+  return this.send(starredPackages, function(err, data){
+    if(err) {
+      debug('failed to obtain starred packages: %s', err.message);
+      return fn(err);
+    }
+    var starredPackages = [];
+    if (data === undefined || data.length <=0 || data[0].rows === undefined) {
+      debug('failed to obtain starred packages');
+      return fn(new Error('failed to obtain starred packages'));
+    }
+    data[0].rows.forEach(function(item) {
+      starredPackages.push(item.value);
+    });
+    return fn(null, starredPackages);
+  });
 };
 
 /**

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -1,0 +1,25 @@
+describe('.users', function() {
+  'use strict';
+
+  var chai = require('chai')
+    , expect = chai.expect;
+
+  var Registry = require('../')
+    , registry = new Registry({ registry: 'https://registry.npmjs.org' });
+
+  var user = 'shwetasabne';
+
+  it('has a users endpoint', function() {
+    expect(registry.users).to.be.a('object');
+  });
+
+  describe('#starred', function() {
+    it('retrieves packages starred by the user if such packages exist', function(next) {
+      registry.users.starred('shwetasabne', function (err, data) {
+        if (err) return next(err);
+        expect(data).to.be.an.Array;
+        next();
+      });
+    });
+  });
+});


### PR DESCRIPTION
What:
Fixing the Users.starred endpoint that returns the list of packages starred by the given user. 

Why:
I have been working on a hobby project that exposes some of the registry functions as Swaggerized REST API (http://api-npm.com/docs/). While working on the project, I found that the existing users.starred endpoint doesn't return expected result.

PR Details:
This PR includes the following:
- [x] Fix for the users.starred endpoint
- [x]  Adding a new test to validate the fix